### PR TITLE
Move CAI_AI::test inside class body

### DIFF
--- a/includes/class-cai-ai.php
+++ b/includes/class-cai-ai.php
@@ -78,8 +78,6 @@ class CAI_AI {
         if ($na == 0 || $nb == 0) return 0.0;
         return $dot / (sqrt($na)*sqrt($nb));
     }
-}
-
 
     public static function test(){
         $opt = get_option('cai_settings', []);
@@ -113,3 +111,4 @@ class CAI_AI {
         }
         return new WP_Error('api_error', 'Bad response from OpenAI');
     }
+}


### PR DESCRIPTION
## Summary
- move the CAI_AI::test method definition into the class body so it is encapsulated with the other static methods

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d649524fd083239172a28402bad7de