### PR TITLE
Move ajax_test_ai method into CAI_REST class

### DIFF
--- a/includes/class-cai-rest.php
+++ b/includes/class-cai-rest.php
@@ -58,8 +58,6 @@ if (!current_user_can('manage_options')) wp_send_json_error('forbidden', 403);
         $res = $this->reindex_all();
         wp_send_json_success($res);
     }
-}
-
 
     public function ajax_test_ai(){
         check_ajax_referer('cai-admin','nonce');
@@ -68,3 +66,4 @@ if (!current_user_can('manage_options')) wp_send_json_error('forbidden', 403);
         if (is_wp_error($res)) wp_send_json_error($res->get_error_message());
         wp_send_json_success(['ok'=>$res]);
     }
+}


### PR DESCRIPTION
## Summary
- move the ajax_test_ai handler back inside the CAI_REST class to keep hooks aligned with methods

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d64955283c8323b71615b3d65e824e