### PR TITLE
Stop bundling OpenAI API key in plugin

### DIFF
--- a/content-architect-ai.php
+++ b/content-architect-ai.php
@@ -15,7 +15,24 @@ define('CAI_VERSION', '1.0.0');
 define('CAI_PLUGIN_FILE', __FILE__);
 define('CAI_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('CAI_PLUGIN_URL', plugin_dir_url(__FILE__));
-if (!defined('CAI_OPENAI_API_KEY')) define('CAI_OPENAI_API_KEY', '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');
+
+if (!function_exists('cai_get_openai_api_key')) {
+    function cai_get_openai_api_key() {
+        static $cached_key = null;
+        if ($cached_key !== null) {
+            return $cached_key;
+        }
+        $key = '';
+        if (defined('CAI_OPENAI_API_KEY') && CAI_OPENAI_API_KEY) {
+            $key = CAI_OPENAI_API_KEY;
+        } else {
+            $options = get_option('cai_settings', []);
+            $key = isset($options['openai_api_key']) ? trim($options['openai_api_key']) : '';
+        }
+        $cached_key = apply_filters('cai_openai_api_key', $key);
+        return $cached_key;
+    }
+}
 
 // Simple PSR-4-like loader
 spl_autoload_register(function($class){

--- a/includes/class-cai-admin.php
+++ b/includes/class-cai-admin.php
@@ -29,12 +29,13 @@ class CAI_Admin {
         register_setting('cai_settings_group', 'cai_settings');
 
         add_settings_section('cai_api', __('OpenAI API', 'content-architect-ai'), function(){
-            echo '<p>'.esc_html__('חיבור ל-OpenAI לצורך עיבוד שפה, סיווג וקיבוץ.', 'content-architect-ai').'</p>';
+            echo '<p>'.esc_html__('חיבור ל-OpenAI לצורך עיבוד שפה, סיווג וקיבוץ. הזינו כאן את מפתח ה-API או הגדירו את הקבוע CAI_OPENAI_API_KEY בקובץ ההגדרות של האתר.', 'content-architect-ai').'</p>';
         }, 'cai_settings');
 
         add_settings_field('openai_api_key', __('OpenAI API Key', 'content-architect-ai'), function(){
             $opt = get_option('cai_settings', []);
             printf('<input type="password" name="cai_settings[openai_api_key]" value="%s" class="regular-text" />', esc_attr($opt['openai_api_key'] ?? ''));
+            echo '<p class="description">'.esc_html__('המפתח נשמר כאן באופן מאובטח. ניתן גם להגדיר קבוע CAI_OPENAI_API_KEY בקובץ wp-config.php.', 'content-architect-ai').'</p>';
         }, 'cai_settings', 'cai_api');
 
         add_settings_field('chat_model', __('דגם לטקסט', 'content-architect-ai'), function(){

--- a/includes/class-cai-ai.php
+++ b/includes/class-cai-ai.php
@@ -5,7 +5,7 @@ class CAI_AI {
 
     public static function chat($prompt, $system='You are an expert SEO and information architect.', $max_tokens=400){
         $opt = get_option('cai_settings', []);
-        $api_key = defined('CAI_OPENAI_API_KEY') && CAI_OPENAI_API_KEY ? CAI_OPENAI_API_KEY : ($opt['openai_api_key'] ?? '');
+        $api_key = cai_get_openai_api_key();
         $model   = $opt['chat_model'] ?? 'gpt-4o-mini';
         if (empty($api_key)) return '';
 
@@ -40,7 +40,7 @@ class CAI_AI {
 
     public static function embedding($text){
         $opt = get_option('cai_settings', []);
-        $api_key = defined('CAI_OPENAI_API_KEY') && CAI_OPENAI_API_KEY ? CAI_OPENAI_API_KEY : ($opt['openai_api_key'] ?? '');
+        $api_key = cai_get_openai_api_key();
         $model   = $opt['embedding_model'] ?? 'text-embedding-3-small';
         if (empty($api_key)) return [];
 
@@ -78,12 +78,10 @@ class CAI_AI {
         if ($na == 0 || $nb == 0) return 0.0;
         return $dot / (sqrt($na)*sqrt($nb));
     }
-}
-
 
     public static function test(){
         $opt = get_option('cai_settings', []);
-        $api_key = defined('CAI_OPENAI_API_KEY') && CAI_OPENAI_API_KEY ? CAI_OPENAI_API_KEY : ($opt['openai_api_key'] ?? '');
+        $api_key = cai_get_openai_api_key();
         $model   = $opt['chat_model'] ?? 'gpt-4o-mini';
         if (empty($api_key)) return new WP_Error('missing_key','OpenAI API key missing');
 
@@ -113,3 +111,4 @@ class CAI_AI {
         }
         return new WP_Error('api_error', 'Bad response from OpenAI');
     }
+}


### PR DESCRIPTION
## Summary
- remove the hard-coded CAI_OPENAI_API_KEY and add a helper that reads the saved option or a user-defined constant
- update the AI service class to call the shared helper for all requests and keep the health check inside the class scope
- extend the settings copy so admins know to enter their OpenAI API key via the settings screen or wp-config.php

## Testing
- php -l content-architect-ai.php
- php -l includes/class-cai-ai.php
- php -l includes/class-cai-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d64957891c8323b4709cd10a73455a