### PR TITLE
Add nonce to admin AJAX requests

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -6,7 +6,7 @@ jQuery(function($){
         e.preventDefault();
         const $btn = $(this);
         $btn.prop('disabled', true).text('מנתח...');
-        $.post(caiVars.ajaxurl, { nonce: caiVars.nonce,  action:'cai_analyze_site' }, function(resp){
+        $.post(caiVars.ajaxurl, { nonce: caiVars.nonce, action:'cai_analyze_site' }, function(resp){
             if(resp && resp.success && resp.data && resp.data.plan){
                 $('#cai-plan').val(resp.data.plan);
             } else {
@@ -21,7 +21,7 @@ jQuery(function($){
         const plan = $('#cai-plan').val();
         const $btn = $(this);
         $btn.prop('disabled', true).text('מיישם...');
-        $.post(caiVars.ajaxurl, { nonce: caiVars.nonce,  action:'cai_apply_arch', plan: plan }, function(resp){
+        $.post(caiVars.ajaxurl, { nonce: caiVars.nonce, action:'cai_apply_arch', plan: plan }, function(resp){
             if(resp && resp.success){
                 alert('נוצרו/עודכנו אשכולות/קטגוריות: ' + JSON.stringify(resp.data.created));
             }else{
@@ -37,7 +37,7 @@ jQuery(function($){
         const $btn = $(this);
         $btn.prop('disabled', true).text('יוצר...');
         $('#cai-generate-log').prepend('<div>הפעלה התחילה...</div>');
-        $.post(caiVars.ajaxurl, { nonce: caiVars.nonce,  action:'cai_generate_now', ppc: ppc }, function(resp){
+        $.post(caiVars.ajaxurl, { nonce: caiVars.nonce, action:'cai_generate_now', ppc: ppc }, function(resp){
             if(resp && resp.success){
                 $('#cai-generate-log').prepend('<div>נוצרו ' + resp.data.created + ' פוסטים: ' + (resp.data.ids||[]).join(', ') + '</div>');
             } else {
@@ -53,7 +53,7 @@ jQuery(function($){
         if(!topic){ alert('נא להזין נושא'); return; }
         const $btn = $(this);
         $btn.prop('disabled', true).text('יוצר...');
-        $.post(caiVars.ajaxurl, { nonce: caiVars.nonce,  action:'cai_generate_from_topic', topic: topic }, function(resp){
+        $.post(caiVars.ajaxurl, { nonce: caiVars.nonce, action:'cai_generate_from_topic', topic: topic }, function(resp){
             if(resp && resp.success){
                 $('#cai-generate-log').prepend('<div>נוצר פוסט #' + resp.data.post_id + '</div>');
             } else {

--- a/includes/class-cai-editor.php
+++ b/includes/class-cai-editor.php
@@ -14,7 +14,7 @@ class CAI_Editor {
                 e.preventDefault();
                 const postId = $(this).data('post');
                 $(this).prop('disabled', true).text('יוצר...');
-                $.post(ajaxurl, { action:'cai_generate_meta', post_id: postId }, function(resp){
+                $.post(ajaxurl, { action:'cai_generate_meta', post_id: postId, nonce: (typeof caiVars !== 'undefined') ? caiVars.nonce : '' }, function(resp){
                     if(resp && resp.success && resp.data){
                         if(resp.data.title) $('input[name="cai_meta_title"]').val(resp.data.title);
                         if(resp.data.description) $('textarea[name="cai_meta_desc"]').val(resp.data.description);
@@ -30,7 +30,7 @@ class CAI_Editor {
                 if(!topic){ alert('נא להזין נושא'); return; }
                 const $btn = $(this);
                 $btn.prop('disabled', true).text('יוצר תוכן...');
-                $.post(ajaxurl, { action:'cai_generate_from_topic', topic: topic }, function(resp){
+                $.post(ajaxurl, { action:'cai_generate_from_topic', topic: topic, nonce: (typeof caiVars !== 'undefined') ? caiVars.nonce : '' }, function(resp){
                     if(resp && resp.success && resp.data && resp.data.post_id){
                         alert('נוצר פוסט #' + resp.data.post_id);
                         location.href = resp.data.edit_link || location.href;
@@ -44,7 +44,7 @@ class CAI_Editor {
                 e.preventDefault();
                 const $btn = $(this);
                 $btn.prop('disabled', true).text('מריץ...');
-                $.post(ajaxurl, { action:'cai_reindex' }, function(resp){
+                $.post(ajaxurl, { action:'cai_reindex', nonce: (typeof caiVars !== 'undefined') ? caiVars.nonce : '' }, function(resp){
                     $('#cai-reindex-log').text(JSON.stringify(resp, null, 2));
                     $btn.prop('disabled', false).text('הפעל אינדוקס');
                 });


### PR DESCRIPTION
## Summary
- ensure every admin-side AJAX helper in admin.js sends the localized nonce alongside its action payload
- update the inline editor helpers to include the same nonce while tolerating the localized data being absent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6495954a88323ac095a7e208e7b85