### PR TITLE
Ensure CAI enhancements class closes constructor correctly

### DIFF
--- a/includes/class-cai-enhancements.php
+++ b/includes/class-cai-enhancements.php
@@ -13,6 +13,8 @@ class CAI_Enhancements {
         add_shortcode('cai_updated', [$this,'updated']);
         add_shortcode('cai_cluster', [$this,'cluster_name']);
         add_shortcode('cai_cluster_posts', [$this,'cluster_posts']);
+
+    }
     
 
     public function author_box(){
@@ -76,8 +78,6 @@ class CAI_Enhancements {
         wp_reset_postdata();
         return $html;
     }
-
-}
 
     // Simple Table of Contents from the_content
     public function toc($atts = []){


### PR DESCRIPTION
## Summary
- close the CAI_Enhancements constructor before the author_box method
- keep all helper methods inside the class definition

## Testing
- php -l includes/class-cai-enhancements.php

------
https://chatgpt.com/codex/tasks/task_e_68d64fcc7b608323ad0feffa671a8879