### PR TITLE
Improve AI JSON handling and add tests

### DIFF
--- a/includes/class-cai-ai.php
+++ b/includes/class-cai-ai.php
@@ -3,11 +3,13 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 class CAI_AI {
 
-    public static function chat($prompt, $system='You are an expert SEO and information architect.', $max_tokens=400){
+    public static function chat($prompt, $system='You are an expert SEO and information architect.', $max_tokens=400, $expect_json=false){
         $opt = get_option('cai_settings', []);
         $api_key = cai_get_openai_api_key();
         $model   = $opt['chat_model'] ?? 'gpt-4o-mini';
-        if (empty($api_key)) return '';
+        if (empty($api_key)){
+            return new WP_Error('missing_key', 'OpenAI API key missing');
+        }
 
         $endpoint = 'https://api.openai.com/v1/chat/completions';
         $body = [
@@ -20,6 +22,14 @@ class CAI_AI {
             'max_tokens' => $max_tokens
         ];
 
+        if ($expect_json){
+            if (is_array($expect_json)){
+                $body['response_format'] = $expect_json;
+            } else {
+                $body['response_format'] = ['type' => 'json_object'];
+            }
+        }
+
         $response = wp_remote_post($endpoint, [
             'headers' => [
                 'Authorization' => 'Bearer ' . $api_key,
@@ -29,13 +39,100 @@ class CAI_AI {
             'body' => wp_json_encode($body),
         ]);
 
-        if (is_wp_error($response)) return '';
-        $code = wp_remote_retrieve_response_code($response);
-        $body = json_decode(wp_remote_retrieve_body($response), true);
-        if ($code >= 200 && $code < 300 && !empty($body['choices'][0]['message']['content'])){
-            return $body['choices'][0]['message']['content'];
+        if (is_wp_error($response)){
+            return $response;
         }
-        return '';
+
+        $code = wp_remote_retrieve_response_code($response);
+        $decoded = json_decode(wp_remote_retrieve_body($response), true);
+        if ($code < 200 || $code >= 300){
+            $message = !empty($decoded['error']['message']) ? $decoded['error']['message'] : 'Unexpected response from OpenAI';
+            return new WP_Error('api_http_error', $message);
+        }
+
+        if (empty($decoded['choices'][0]['message']['content'])){
+            return new WP_Error('api_missing_content', 'Empty response from OpenAI');
+        }
+
+        $content = $decoded['choices'][0]['message']['content'];
+        if (!is_string($content)){
+            return new WP_Error('api_invalid_content', 'Invalid content type returned from OpenAI');
+        }
+
+        $content = trim($content);
+        if ($expect_json){
+            $content = self::normalize_json_response($content);
+        }
+
+        return $content;
+    }
+
+    public static function normalize_json_response($text){
+        if (!is_string($text)) return '';
+
+        $normalized = trim($text);
+
+        if (preg_match('/^```(?:json)?\s*([\s\S]*?)```/i', $normalized, $matches)){
+            $normalized = $matches[1];
+        }
+
+        $normalized = trim($normalized);
+
+        if (stripos($normalized, 'json') === 0){
+            $candidate = ltrim(substr($normalized, 4));
+            if ($candidate !== '' && ($candidate[0] === '{' || $candidate[0] === '[')){
+                $normalized = $candidate;
+            }
+        }
+
+        $normalized = trim($normalized);
+
+        $firstBrace = strpos($normalized, '{');
+        $firstBracket = strpos($normalized, '[');
+        $start = false;
+        if ($firstBrace !== false && $firstBracket !== false){
+            $start = min($firstBrace, $firstBracket);
+        } elseif ($firstBrace !== false){
+            $start = $firstBrace;
+        } elseif ($firstBracket !== false){
+            $start = $firstBracket;
+        }
+        if ($start !== false && $start > 0){
+            $normalized = substr($normalized, $start);
+        }
+
+        $endBrace = strrpos($normalized, '}');
+        $endBracket = strrpos($normalized, ']');
+        $end = false;
+        if ($endBrace !== false && $endBracket !== false){
+            $end = max($endBrace, $endBracket);
+        } elseif ($endBrace !== false){
+            $end = $endBrace;
+        } elseif ($endBracket !== false){
+            $end = $endBracket;
+        }
+        if ($end !== false){
+            $normalized = substr($normalized, 0, $end + 1);
+        }
+
+        return trim($normalized);
+    }
+
+    public static function parse_json_response($text){
+        $normalized = self::normalize_json_response($text);
+        if ($normalized === ''){
+            return new WP_Error('empty_json', 'Empty AI JSON response');
+        }
+
+        $data = json_decode($normalized, true);
+        if (json_last_error() !== JSON_ERROR_NONE){
+            return new WP_Error('json_decode_error', 'Failed to decode AI JSON: ' . json_last_error_msg(), ['raw'=>$normalized]);
+        }
+
+        return [
+            'data' => $data,
+            'raw'  => $normalized,
+        ];
     }
 
     public static function embedding($text){

--- a/includes/class-cai-clustering.php
+++ b/includes/class-cai-clustering.php
@@ -37,6 +37,9 @@ class CAI_Clustering {
         } else {
             // ask AI to propose a cluster name
             $name = CAI_AI::chat('Suggest a 2-4 word topic cluster name in Hebrew for this content: '.get_the_title($post_id));
+            if (is_wp_error($name)){
+                $name = '';
+            }
             $name = sanitize_text_field($name ?: 'אשכול חדש');
             $term = wp_insert_term($name, 'topic_cluster');
             if (!is_wp_error($term)){

--- a/includes/class-cai-rest.php
+++ b/includes/class-cai-rest.php
@@ -41,15 +41,28 @@ if (!current_user_can('edit_posts')) wp_send_json_error('forbidden', 403);
         if (!$pid) wp_send_json_error('missing id', 400);
         $post = get_post($pid);
         $prompt = 'Create an SEO title (<=60 chars) and a meta description (<=155 chars) in Hebrew for the following article. Return JSON with keys title, description. Title: "'.get_the_title($pid).'" Content: ' . wp_strip_all_tags($post->post_content);
-        $json = CAI_AI::chat($prompt, 'You are a world-class SEO copywriter. Return JSON only.', 200);
-        $data = json_decode($json, true);
+        $json = CAI_AI::chat($prompt, 'You are a world-class SEO copywriter. Return JSON only.', 200, true);
+        if (is_wp_error($json)){
+            wp_send_json_error($json->get_error_message());
+        }
+
+        $parsed = CAI_AI::parse_json_response($json);
+        if (is_wp_error($parsed)){
+            $data = $parsed->get_error_data();
+            wp_send_json_error([
+                'message' => $parsed->get_error_message(),
+                'raw'     => $data['raw'] ?? $json,
+            ]);
+        }
+
+        $data = $parsed['data'];
         if (is_array($data)){
             update_post_meta($pid, '_cai_meta_title', sanitize_text_field($data['title'] ?? ''));
             update_post_meta($pid, '_cai_meta_desc', sanitize_textarea_field($data['description'] ?? ''));
             wp_send_json_success($data);
-        } else {
-            wp_send_json_error('bad ai response');
         }
+
+        wp_send_json_error('bad ai response');
     }
 
     public function ajax_reindex(){

--- a/tests/test-json-normalization.php
+++ b/tests/test-json-normalization.php
@@ -1,0 +1,40 @@
+<?php
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/../');
+}
+
+require_once ABSPATH . 'includes/class-cai-ai.php';
+
+function assert_decodes(string $label, string $input, array $expected): void {
+    $normalized = CAI_AI::normalize_json_response($input);
+    $decoded = json_decode($normalized, true);
+    if ($decoded !== $expected) {
+        throw new RuntimeException(sprintf(
+            '%s failed: expected %s got %s',
+            $label,
+            json_encode($expected, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            json_encode($decoded, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+        ));
+    }
+}
+
+function assert_decodable(string $label, string $input): void {
+    $normalized = CAI_AI::normalize_json_response($input);
+    $decoded = json_decode($normalized, true);
+    if (!is_array($decoded) && !is_object($decoded)) {
+        throw new RuntimeException(sprintf('%s failed to decode JSON: %s', $label, json_last_error_msg()));
+    }
+}
+
+try {
+    assert_decodes('code fences', "```json\n{\"title\":\"שלום\"}\n```", ['title' => 'שלום']);
+    assert_decodes('json prefix', "json\n{\"clusters\":[1,2,3]}", ['clusters' => [1,2,3]]);
+    assert_decodes('leading explanation', "Here is your JSON:\n{\"ok\":true}\nThanks!", ['ok' => true]);
+    assert_decodes('trailing fence text', "```JSON\n[{\"title\":\"A\"}]\n```\nExtra", [['title' => 'A']]);
+    assert_decodable('whitespace robustness', "    ```json\n{\n  \"value\": 42\n}\n```    ");
+    echo "All normalization tests passed\n";
+    exit(0);
+} catch (Throwable $e) {
+    fwrite(STDERR, $e->getMessage() . "\n");
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- add optional JSON-aware response formatting to `CAI_AI::chat` and provide helpers for normalizing and parsing responses
- update generators, REST endpoints, and clustering logic to use the new helpers and gracefully handle API errors or malformed JSON
- add lightweight normalization tests that cover common OpenAI code-fence responses

## Testing
- php tests/test-json-normalization.php

------
https://chatgpt.com/codex/tasks/task_e_68d65342f6e883238f25a6e15bf7bcd1