### PR TITLE
Improve AI error handling and admin feedback

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,7 +1,30 @@
 /* global caiVars */
-// placeholder
+function caiExtractError(resp, fallback){
+    var message = fallback || 'שגיאה';
+    if (!resp){
+        return message;
+    }
+    var data = typeof resp.data !== 'undefined' ? resp.data : null;
+    if (typeof data === 'string' && data){
+        message = data;
+    } else if (data && typeof data === 'object'){
+        if (data.message){
+            message = data.message;
+        }
+        if (data.details){
+            var details = typeof data.details === 'string' ? data.details : JSON.stringify(data.details);
+            if (details){
+                message += ' (' + details + ')';
+            }
+        }
+    } else if (resp.message){
+        message = resp.message;
+    }
+    return message;
+}
+
 jQuery(function($){
-    // Generation page
+
     $('#cai-analyze-site').on('click', function(e){
         e.preventDefault();
         const $btn = $(this);
@@ -10,7 +33,7 @@ jQuery(function($){
             if(resp && resp.success && resp.data && resp.data.plan){
                 $('#cai-plan').val(resp.data.plan);
             } else {
-                alert('שגיאה בניתוח האתר');
+                alert(caiExtractError(resp, 'שגיאה בניתוח האתר'));
             }
             $btn.prop('disabled', false).text('נתח אתר והצע אשכולות');
         });
@@ -25,7 +48,7 @@ jQuery(function($){
             if(resp && resp.success){
                 alert('נוצרו/עודכנו אשכולות/קטגוריות: ' + JSON.stringify(resp.data.created));
             }else{
-                alert('שגיאה ביישום הארכיטקטורה');
+                alert(caiExtractError(resp, 'שגיאה ביישום הארכיטקטורה'));
             }
             $btn.prop('disabled', false).text('יישם ארכיטקטורה והכן קטגוריות');
         });
@@ -41,7 +64,7 @@ jQuery(function($){
             if(resp && resp.success){
                 $('#cai-generate-log').prepend('<div>נוצרו ' + resp.data.created + ' פוסטים: ' + (resp.data.ids||[]).join(', ') + '</div>');
             } else {
-                $('#cai-generate-log').prepend('<div>כשלון בהרצה</div>');
+                $('#cai-generate-log').prepend('<div>כשלון בהרצה: ' + caiExtractError(resp, '') + '</div>');
             }
             $btn.prop('disabled', false).text('צור עכשיו');
         });
@@ -57,7 +80,7 @@ jQuery(function($){
             if(resp && resp.success){
                 $('#cai-generate-log').prepend('<div>נוצר פוסט #' + resp.data.post_id + '</div>');
             } else {
-                $('#cai-generate-log').prepend('<div>כשלון ביצירת פוסט</div>');
+                $('#cai-generate-log').prepend('<div>כשלון ביצירת פוסט: ' + caiExtractError(resp, '') + '</div>');
             }
             $btn.prop('disabled', false).text('יצירת פוסט יחיד');
         });
@@ -73,7 +96,7 @@ jQuery(function($){
             if(resp && resp.success){
                 $('#cai-test-result').text('✓ חיבור תקין ('+(resp.data.ok||'OK')+')');
             } else {
-                $('#cai-test-result').text('✗ שגיאה: '+ (resp && resp.data ? resp.data : ''));
+                $('#cai-test-result').text('✗ שגיאה: '+ caiExtractError(resp, ''));
             }
             $btn.prop('disabled', false).text('בדוק חיבור');
         });

--- a/includes/class-cai-clustering.php
+++ b/includes/class-cai-clustering.php
@@ -36,7 +36,36 @@ class CAI_Clustering {
             wp_set_object_terms($post_id, intval($best_term_id), 'topic_cluster', false);
         } else {
             // ask AI to propose a cluster name
-            $name = CAI_AI::chat('Suggest a 2-4 word topic cluster name in Hebrew for this content: '.get_the_title($post_id));
+            $name_response = CAI_AI::chat('Suggest a 2-4 word topic cluster name in Hebrew for this content: '.get_the_title($post_id));
+            if (is_wp_error($name_response)){
+                $details = $name_response->get_error_data();
+                if (!empty($details) && !is_scalar($details)){
+                    $details = wp_json_encode($details);
+                }
+                if (is_string($details)){
+                    $original_details = $details;
+                    if (function_exists('mb_substr')){
+                        $details = mb_substr($original_details, 0, 400);
+                        $length = function_exists('mb_strlen') ? mb_strlen($original_details) : strlen($original_details);
+                        if ($length > 400){
+                            $details .= '…';
+                        }
+                    } else {
+                        $details = substr($original_details, 0, 400);
+                        if (strlen($original_details) > 400){
+                            $details .= '…';
+                        }
+                    }
+                }
+                $message = 'CAI clustering error: '.$name_response->get_error_message();
+                if (!empty($details)){
+                    $message .= ' | '.$details;
+                }
+                error_log($message);
+                $name = 'אשכול חדש';
+            } else {
+                $name = $name_response;
+            }
             $name = sanitize_text_field($name ?: 'אשכול חדש');
             $term = wp_insert_term($name, 'topic_cluster');
             if (!is_wp_error($term)){


### PR DESCRIPTION
## Summary
- return detailed WP_Error objects from the OpenAI chat client when requests fail or return bad status codes
- propagate AI error handling through generators, REST endpoints, and clustering while logging truncated diagnostics
- surface server-side failure messages in the admin UI so operators understand why actions failed

## Testing
- php -l includes/class-cai-ai.php
- php -l includes/class-cai-generator.php
- php -l includes/class-cai-clustering.php
- php -l includes/class-cai-rest.php

------
https://chatgpt.com/codex/tasks/task_e_68d653384c5883238bb21d7b341b049f