### PR TITLE
Ensure TOC markup is applied during current render

### DIFF
--- a/includes/class-cai-enhancements.php
+++ b/includes/class-cai-enhancements.php
@@ -3,6 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 class CAI_Enhancements {
 
+    private $filtered_content;
+
     public function __construct(){
         add_shortcode('cai_toc', [$this,'toc']);
         add_shortcode('cai_reading_time', [$this,'reading_time']);
@@ -103,8 +105,19 @@ class CAI_Enhancements {
 
         // replace content with injected anchors
         remove_filter('the_content', [$this,'auto_append_toc'], 1);
-        add_filter('the_content', function($content) use ($html){ return $html; }, 1);
+        $this->filtered_content = $html;
+        add_filter('the_content', [$this,'replace_toc_content'], 99);
         return $out;
+    }
+
+    public function replace_toc_content($content){
+        if ($this->filtered_content === null) {
+            return $content;
+        }
+        $updated = $this->filtered_content;
+        $this->filtered_content = null;
+        remove_filter('the_content', [$this,'replace_toc_content'], 99);
+        return $updated;
     }
 
     public function reading_time($atts = []){


### PR DESCRIPTION
## Summary
- cache the TOC-filtered post content so headings receive IDs in the same render
- add a late the_content filter that swaps in the rewritten markup and then removes itself

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d65b37423483239676f4356f916195